### PR TITLE
remove experimental http3

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,12 +1,6 @@
 {
     # Debug
     {$DEBUG}
-    # HTTP/3 support
-    servers {
-        protocol {
-            experimental_http3
-        }
-    }
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
as of caddy 2.6 http3 is enabled by default, and no longer an experimental setting. remove the config so that it can start